### PR TITLE
Add a way to pause and stop simulations cleanly

### DIFF
--- a/turtleFSI/utils/argpar.py
+++ b/turtleFSI/utils/argpar.py
@@ -248,6 +248,10 @@ def parse():
     parser.add_argument("--d-deg", metavar="Deformation degree", type=int,
                         help="Set degree of deformation", default=None)
 
+    # Misc settings
+    parser.add_argument("--killtime", type=int, default=None,
+                        help="Stop simulations cleanly after the given number of seconds")
+
     # Add the posibility pass unspecificed arguments
     parser.add_argument("--new-arguments", action=StoreDictKeyPair, nargs="+", metavar="KEY=VAL",
                         help="Add any non-defined argument where the value is a string," +


### PR DESCRIPTION
This PR will add a way to pause and stop simulations cleanly.

* To pause a running simulation, simply put a file called `pauseturtle` in the simulation results folder. Remove the file to continue the simulation.
* To stop the simulation cleanly, simply put a file called `killturtle` in the simulation results folder.

This is the same functionality that is available in [Oasis](https://github.com/mikaem/Oasis) (`pauseoasis` and `killoasis`). 