### PR TITLE
Feature/multiple fluid regions

### DIFF
--- a/turtleFSI/modules/biharmonic.py
+++ b/turtleFSI/modules/biharmonic.py
@@ -7,7 +7,7 @@ from dolfin import inner, grad
 
 
 def extrapolate_setup(F_fluid_linear, extrapolation_sub_type, d_, w_, phi, beta, dx_f,
-                      dx_f_id, ds, n, bc_ids, **namespace):
+                      dx_f_id_list, ds, n, bc_ids, **namespace):
     """
     Biharmonic lifting operator. Should be used for large deformations.
 
@@ -31,7 +31,7 @@ def extrapolate_setup(F_fluid_linear, extrapolation_sub_type, d_, w_, phi, beta,
     alpha_u = 0.01
     F_ext1 = 0
     F_ext2 = 0
-    for fluid_region in range(len(dx_f_id)): # for all fluid regions
+    for fluid_region in range(len(dx_f_id_list)): # for all fluid regions
         F_ext1 += alpha_u * inner(w_["n"], beta) * dx_f[fluid_region] - alpha_u * inner(grad(d_["n"]), grad(beta)) * dx_f[fluid_region]
         F_ext2 += alpha_u * inner(grad(w_["n"]), grad(phi)) * dx_f[fluid_region]
 

--- a/turtleFSI/modules/biharmonic.py
+++ b/turtleFSI/modules/biharmonic.py
@@ -7,7 +7,7 @@ from dolfin import inner, grad
 
 
 def extrapolate_setup(F_fluid_linear, extrapolation_sub_type, d_, w_, phi, beta, dx_f,
-                      ds, n, bc_ids, **namespace):
+                      dx_f_id, ds, n, bc_ids, **namespace):
     """
     Biharmonic lifting operator. Should be used for large deformations.
 
@@ -29,8 +29,11 @@ def extrapolate_setup(F_fluid_linear, extrapolation_sub_type, d_, w_, phi, beta,
     """
 
     alpha_u = 0.01
-    F_ext1 = alpha_u * inner(w_["n"], beta) * dx_f - alpha_u * inner(grad(d_["n"]), grad(beta)) * dx_f
-    F_ext2 = alpha_u * inner(grad(w_["n"]), grad(phi)) * dx_f
+    F_ext1 = 0
+    F_ext2 = 0
+    for fluid_region in range(len(dx_f_id)): # for all fluid regions
+        F_ext1 += alpha_u * inner(w_["n"], beta) * dx_f[fluid_region] - alpha_u * inner(grad(d_["n"]), grad(beta)) * dx_f[fluid_region]
+        F_ext2 += alpha_u * inner(grad(w_["n"]), grad(phi)) * dx_f[fluid_region]
 
     if extrapolation_sub_type == "constrained_disp_vel":
         for i in bc_ids:

--- a/turtleFSI/modules/elastic.py
+++ b/turtleFSI/modules/elastic.py
@@ -7,7 +7,7 @@ from turtleFSI.modules import *
 from dolfin import CellVolume, inner, grad, inv
 
 
-def extrapolate_setup(F_fluid_linear, mesh, d_, phi, gamma, dx_f, **namespace):
+def extrapolate_setup(F_fluid_linear, mesh, d_, phi, gamma, dx_f,dx_f_id, **namespace):
     """
     Elastic lifting operator solving the equation of linear elasticity.
 
@@ -19,8 +19,10 @@ def extrapolate_setup(F_fluid_linear, mesh, d_, phi, gamma, dx_f, **namespace):
     nu = 0.25
     alpha_lam = nu * E_y / ((1.0 + nu) * (1.0 - 2.0 * nu))
     alpha_mu = E_y / (2.0 * (1.0 + nu))
-    F_extrapolate = inner(J_(d_["n"]) * S_linear(d_["n"], alpha_mu, alpha_lam) *
-                          inv(F_(d_["n"])).T, grad(phi))*dx_f
+    F_extrapolate = 0
+    for fluid_region in range(len(dx_f_id)): # for all fluid regions
+        F_extrapolate += inner(J_(d_["n"]) * S_linear(d_["n"], alpha_mu, alpha_lam) *
+                              inv(F_(d_["n"])).T, grad(phi))*dx_f[fluid_region]
 
     F_fluid_linear += F_extrapolate
 

--- a/turtleFSI/modules/elastic.py
+++ b/turtleFSI/modules/elastic.py
@@ -7,7 +7,7 @@ from turtleFSI.modules import *
 from dolfin import CellVolume, inner, grad, inv
 
 
-def extrapolate_setup(F_fluid_linear, mesh, d_, phi, gamma, dx_f,dx_f_id, **namespace):
+def extrapolate_setup(F_fluid_linear, mesh, d_, phi, gamma, dx_f, dx_f_id, **namespace):
     """
     Elastic lifting operator solving the equation of linear elasticity.
 

--- a/turtleFSI/modules/elastic.py
+++ b/turtleFSI/modules/elastic.py
@@ -7,7 +7,7 @@ from turtleFSI.modules import *
 from dolfin import CellVolume, inner, grad, inv
 
 
-def extrapolate_setup(F_fluid_linear, mesh, d_, phi, gamma, dx_f, dx_f_id, **namespace):
+def extrapolate_setup(F_fluid_linear, mesh, d_, phi, gamma, dx_f, dx_f_id_list, **namespace):
     """
     Elastic lifting operator solving the equation of linear elasticity.
 
@@ -20,7 +20,7 @@ def extrapolate_setup(F_fluid_linear, mesh, d_, phi, gamma, dx_f, dx_f_id, **nam
     alpha_lam = nu * E_y / ((1.0 + nu) * (1.0 - 2.0 * nu))
     alpha_mu = E_y / (2.0 * (1.0 + nu))
     F_extrapolate = 0
-    for fluid_region in range(len(dx_f_id)): # for all fluid regions
+    for fluid_region in range(len(dx_f_id_list)): # for all fluid regions
         F_extrapolate += inner(J_(d_["n"]) * S_linear(d_["n"], alpha_mu, alpha_lam) *
                               inv(F_(d_["n"])).T, grad(phi))*dx_f[fluid_region]
 

--- a/turtleFSI/modules/fluid.py
+++ b/turtleFSI/modules/fluid.py
@@ -30,8 +30,8 @@ def fluid_setup(v_, p_, d_, psi, gamma, dx_f, mu_f, rho_f, k, theta, **namespace
         # computation of the Jacobian matrix.
     
         # Temporal derivative
-        F_fluid_nonlinear = rho_f / k * inner(J_(d_["n"]) * theta0 * (v_["n"] - v_["n-1"]), psi) * dx_f[fluid_region]
-        F_fluid_linear = rho_f / k * inner(J_(d_["n-1"]) * theta1 * (v_["n"] - v_["n-1"]), psi) * dx_f[fluid_region]
+        F_fluid_nonlinear += rho_f / k * inner(J_(d_["n"]) * theta0 * (v_["n"] - v_["n-1"]), psi) * dx_f[fluid_region]
+        F_fluid_linear += rho_f / k * inner(J_(d_["n-1"]) * theta1 * (v_["n"] - v_["n-1"]), psi) * dx_f[fluid_region]
     
         # Convection
         F_fluid_nonlinear += theta0 * rho_f * inner(grad(v_["n"]) * inv(F_(d_["n"])) *

--- a/turtleFSI/modules/fluid.py
+++ b/turtleFSI/modules/fluid.py
@@ -7,7 +7,7 @@ from turtleFSI.modules import *
 from dolfin import Constant, inner, inv, grad, div
 
 
-def fluid_setup(v_, p_, d_, psi, gamma, dx_f, dx_f_id, mu_f, rho_f, k, theta, **namespace):
+def fluid_setup(v_, p_, d_, psi, gamma, dx_f, dx_f_id_list, mu_f_list, rho_f, k, theta, **namespace):
     """
     ALE formulation (theta-scheme) of the incompressible Navier-Stokes flow problem:
 
@@ -21,7 +21,7 @@ def fluid_setup(v_, p_, d_, psi, gamma, dx_f, dx_f_id, mu_f, rho_f, k, theta, **
     F_fluid_linear = 0
     F_fluid_nonlinear = 0
 
-    for fluid_region in range(len(dx_f_id)):
+    for fluid_region in range(len(dx_f_id_list)):
 
         # Note that we here split the equation into a linear and nonlinear part for faster
         # computation of the Jacobian matrix.
@@ -41,9 +41,9 @@ def fluid_setup(v_, p_, d_, psi, gamma, dx_f, dx_f_id, mu_f, rho_f, k, theta, **
                                    inv(F_(d_["n"])).T, grad(psi)) * dx_f[fluid_region]
     
         # Stress from velocity
-        F_fluid_nonlinear += theta0 * inner(J_(d_["n"]) * sigma_f_u(v_["n"], d_["n"], mu_f[fluid_region]) *
+        F_fluid_nonlinear += theta0 * inner(J_(d_["n"]) * sigma_f_u(v_["n"], d_["n"], mu_f_list[fluid_region]) *
                                             inv(F_(d_["n"])).T, grad(psi)) * dx_f[fluid_region]
-        F_fluid_linear += theta1 * inner(J_(d_["n-1"]) * sigma_f_u(v_["n-1"], d_["n-1"], mu_f[fluid_region])
+        F_fluid_linear += theta1 * inner(J_(d_["n-1"]) * sigma_f_u(v_["n-1"], d_["n-1"], mu_f_list[fluid_region])
                                          * inv(F_(d_["n-1"])).T, grad(psi)) * dx_f[fluid_region]
     
         # Divergence free term

--- a/turtleFSI/modules/fluid.py
+++ b/turtleFSI/modules/fluid.py
@@ -18,34 +18,42 @@ def fluid_setup(v_, p_, d_, psi, gamma, dx_f, mu_f, rho_f, k, theta, **namespace
     theta0 = Constant(theta)
     theta1 = Constant(1 - theta)
 
-    # Note that we here split the equation into a linear and nonlinear part for faster
-    # computation of the Jacobian matrix.
+    if isinstance(mu_f,list)==False: # If there aren't multpile fluid regions, convert fluid viscosity to list
+        mu_f=[mu_f]
 
-    # Temporal derivative
-    F_fluid_nonlinear = rho_f / k * inner(J_(d_["n"]) * theta0 * (v_["n"] - v_["n-1"]), psi) * dx_f
-    F_fluid_linear = rho_f / k * inner(J_(d_["n-1"]) * theta1 * (v_["n"] - v_["n-1"]), psi) * dx_f
+    F_fluid_linear = 0
+    F_fluid_nonlinear = 0
 
-    # Convection
-    F_fluid_nonlinear += theta0 * rho_f * inner(grad(v_["n"]) * inv(F_(d_["n"])) *
-                                                J_(d_["n"]) * v_["n"], psi) * dx_f
-    F_fluid_linear += theta1 * rho_f * inner(grad(v_["n-1"]) * inv(F_(d_["n-1"])) *
-                                             J_(d_["n-1"]) * v_["n-1"], psi) * dx_f
+    for fluid_region in range(len(mu_f)):
 
-    # Stress from pressure
-    F_fluid_nonlinear += inner(J_(d_["n"]) * sigma_f_p(p_["n"], d_["n"]) *
-                               inv(F_(d_["n"])).T, grad(psi)) * dx_f
-
-    # Stress from velocity
-    F_fluid_nonlinear += theta0 * inner(J_(d_["n"]) * sigma_f_u(v_["n"], d_["n"], mu_f) *
-                                        inv(F_(d_["n"])).T, grad(psi)) * dx_f
-    F_fluid_linear += theta1 * inner(J_(d_["n-1"]) * sigma_f_u(v_["n-1"], d_["n-1"], mu_f)
-                                     * inv(F_(d_["n-1"])).T, grad(psi)) * dx_f
-
-    # Divergence free term
-    F_fluid_nonlinear += inner(div(J_(d_["n"]) * inv(F_(d_["n"])) * v_["n"]), gamma) * dx_f
-
-    # ALE term
-    F_fluid_nonlinear -= rho_f / k * inner(J_(d_["n"]) * grad(v_["n"]) * inv(F_(d_["n"])) *
+        # Note that we here split the equation into a linear and nonlinear part for faster
+        # computation of the Jacobian matrix.
+    
+        # Temporal derivative
+        F_fluid_nonlinear = rho_f / k * inner(J_(d_["n"]) * theta0 * (v_["n"] - v_["n-1"]), psi) * dx_f
+        F_fluid_linear = rho_f / k * inner(J_(d_["n-1"]) * theta1 * (v_["n"] - v_["n-1"]), psi) * dx_f
+    
+        # Convection
+        F_fluid_nonlinear += theta0 * rho_f * inner(grad(v_["n"]) * inv(F_(d_["n"])) *
+                                                    J_(d_["n"]) * v_["n"], psi) * dx_f
+        F_fluid_linear += theta1 * rho_f * inner(grad(v_["n-1"]) * inv(F_(d_["n-1"])) *
+                                                 J_(d_["n-1"]) * v_["n-1"], psi) * dx_f
+    
+        # Stress from pressure
+        F_fluid_nonlinear += inner(J_(d_["n"]) * sigma_f_p(p_["n"], d_["n"]) *
+                                   inv(F_(d_["n"])).T, grad(psi)) * dx_f
+    
+        # Stress from velocity
+        F_fluid_nonlinear += theta0 * inner(J_(d_["n"]) * sigma_f_u(v_["n"], d_["n"], mu_f[fluid_region]) *
+                                            inv(F_(d_["n"])).T, grad(psi)) * dx_f
+        F_fluid_linear += theta1 * inner(J_(d_["n-1"]) * sigma_f_u(v_["n-1"], d_["n-1"], mu_f[fluid_region])
+                                         * inv(F_(d_["n-1"])).T, grad(psi)) * dx_f
+    
+        # Divergence free term
+        F_fluid_nonlinear += inner(div(J_(d_["n"]) * inv(F_(d_["n"])) * v_["n"]), gamma) * dx_f
+    
+        # ALE term
+        F_fluid_nonlinear -= rho_f / k * inner(J_(d_["n"]) * grad(v_["n"]) * inv(F_(d_["n"])) *
                                            (d_["n"] - d_["n-1"]), psi) * dx_f
 
     return dict(F_fluid_linear=F_fluid_linear, F_fluid_nonlinear=F_fluid_nonlinear)

--- a/turtleFSI/modules/fluid.py
+++ b/turtleFSI/modules/fluid.py
@@ -30,30 +30,30 @@ def fluid_setup(v_, p_, d_, psi, gamma, dx_f, mu_f, rho_f, k, theta, **namespace
         # computation of the Jacobian matrix.
     
         # Temporal derivative
-        F_fluid_nonlinear = rho_f / k * inner(J_(d_["n"]) * theta0 * (v_["n"] - v_["n-1"]), psi) * dx_f
-        F_fluid_linear = rho_f / k * inner(J_(d_["n-1"]) * theta1 * (v_["n"] - v_["n-1"]), psi) * dx_f
+        F_fluid_nonlinear = rho_f / k * inner(J_(d_["n"]) * theta0 * (v_["n"] - v_["n-1"]), psi) * dx_f[fluid_region]
+        F_fluid_linear = rho_f / k * inner(J_(d_["n-1"]) * theta1 * (v_["n"] - v_["n-1"]), psi) * dx_f[fluid_region]
     
         # Convection
         F_fluid_nonlinear += theta0 * rho_f * inner(grad(v_["n"]) * inv(F_(d_["n"])) *
-                                                    J_(d_["n"]) * v_["n"], psi) * dx_f
+                                                    J_(d_["n"]) * v_["n"], psi) * dx_f[fluid_region]
         F_fluid_linear += theta1 * rho_f * inner(grad(v_["n-1"]) * inv(F_(d_["n-1"])) *
-                                                 J_(d_["n-1"]) * v_["n-1"], psi) * dx_f
+                                                 J_(d_["n-1"]) * v_["n-1"], psi) * dx_f[fluid_region]
     
         # Stress from pressure
         F_fluid_nonlinear += inner(J_(d_["n"]) * sigma_f_p(p_["n"], d_["n"]) *
-                                   inv(F_(d_["n"])).T, grad(psi)) * dx_f
+                                   inv(F_(d_["n"])).T, grad(psi)) * dx_f[fluid_region]
     
         # Stress from velocity
         F_fluid_nonlinear += theta0 * inner(J_(d_["n"]) * sigma_f_u(v_["n"], d_["n"], mu_f[fluid_region]) *
-                                            inv(F_(d_["n"])).T, grad(psi)) * dx_f
+                                            inv(F_(d_["n"])).T, grad(psi)) * dx_f[fluid_region]
         F_fluid_linear += theta1 * inner(J_(d_["n-1"]) * sigma_f_u(v_["n-1"], d_["n-1"], mu_f[fluid_region])
-                                         * inv(F_(d_["n-1"])).T, grad(psi)) * dx_f
+                                         * inv(F_(d_["n-1"])).T, grad(psi)) * dx_f[fluid_region]
     
         # Divergence free term
-        F_fluid_nonlinear += inner(div(J_(d_["n"]) * inv(F_(d_["n"])) * v_["n"]), gamma) * dx_f
+        F_fluid_nonlinear += inner(div(J_(d_["n"]) * inv(F_(d_["n"])) * v_["n"]), gamma) * dx_f[fluid_region]
     
         # ALE term
         F_fluid_nonlinear -= rho_f / k * inner(J_(d_["n"]) * grad(v_["n"]) * inv(F_(d_["n"])) *
-                                           (d_["n"] - d_["n-1"]), psi) * dx_f
+                                           (d_["n"] - d_["n-1"]), psi) * dx_f[fluid_region]
 
     return dict(F_fluid_linear=F_fluid_linear, F_fluid_nonlinear=F_fluid_nonlinear)

--- a/turtleFSI/modules/fluid.py
+++ b/turtleFSI/modules/fluid.py
@@ -7,7 +7,7 @@ from turtleFSI.modules import *
 from dolfin import Constant, inner, inv, grad, div
 
 
-def fluid_setup(v_, p_, d_, psi, gamma, dx_f, mu_f, rho_f, k, theta, **namespace):
+def fluid_setup(v_, p_, d_, psi, gamma, dx_f, dx_f_id, mu_f, rho_f, k, theta, **namespace):
     """
     ALE formulation (theta-scheme) of the incompressible Navier-Stokes flow problem:
 
@@ -18,13 +18,10 @@ def fluid_setup(v_, p_, d_, psi, gamma, dx_f, mu_f, rho_f, k, theta, **namespace
     theta0 = Constant(theta)
     theta1 = Constant(1 - theta)
 
-    if isinstance(mu_f,list)==False: # If there aren't multpile fluid regions, convert fluid viscosity to list
-        mu_f=[mu_f]
-
     F_fluid_linear = 0
     F_fluid_nonlinear = 0
 
-    for fluid_region in range(len(mu_f)):
+    for fluid_region in range(len(dx_f_id)):
 
         # Note that we here split the equation into a linear and nonlinear part for faster
         # computation of the Jacobian matrix.

--- a/turtleFSI/modules/laplace.py
+++ b/turtleFSI/modules/laplace.py
@@ -8,7 +8,7 @@ from turtleFSI.modules import *
 
 
 def extrapolate_setup(F_fluid_linear, extrapolation_sub_type, mesh, d_, phi,
-                      dx_f, **namespace):
+                      dx_f,mu_f, **namespace):
     """
     Laplace lifting operator. Can be used for small to moderate deformations.
     The diffusion parameter "alfa", which is specified by "extrapolation_sub_type",
@@ -41,7 +41,8 @@ def extrapolate_setup(F_fluid_linear, extrapolation_sub_type, mesh, d_, phi,
     else:
         raise RuntimeError("Could not find extrapolation method {}".format(extrapolation_sub_type))
 
-    F_extrapolate = alfa * inner(grad(d_["n"]), grad(phi)) * dx_f
-    F_fluid_linear += F_extrapolate
+    for fluid_region in range(len(mu_f)):
+        F_extrapolate = alfa * inner(grad(d_["n"]), grad(phi)) * dx_f[fluid_region]
+        F_fluid_linear += F_extrapolate
 
     return dict(F_fluid_linear=F_fluid_linear)

--- a/turtleFSI/modules/laplace.py
+++ b/turtleFSI/modules/laplace.py
@@ -8,7 +8,7 @@ from turtleFSI.modules import *
 
 
 def extrapolate_setup(F_fluid_linear, extrapolation_sub_type, mesh, d_, phi,
-                      dx_f,mu_f, **namespace):
+                      dx_f, dx_f_id, **namespace):
     """
     Laplace lifting operator. Can be used for small to moderate deformations.
     The diffusion parameter "alfa", which is specified by "extrapolation_sub_type",
@@ -41,7 +41,7 @@ def extrapolate_setup(F_fluid_linear, extrapolation_sub_type, mesh, d_, phi,
     else:
         raise RuntimeError("Could not find extrapolation method {}".format(extrapolation_sub_type))
 
-    for fluid_region in range(len(mu_f)):
+    for fluid_region in range(len(dx_f_id)): # for all fluid regions
         F_extrapolate = alfa * inner(grad(d_["n"]), grad(phi)) * dx_f[fluid_region]
         F_fluid_linear += F_extrapolate
 

--- a/turtleFSI/modules/laplace.py
+++ b/turtleFSI/modules/laplace.py
@@ -8,7 +8,7 @@ from turtleFSI.modules import *
 
 
 def extrapolate_setup(F_fluid_linear, extrapolation_sub_type, mesh, d_, phi,
-                      dx_f, dx_f_id, **namespace):
+                      dx_f, dx_f_id_list, **namespace):
     """
     Laplace lifting operator. Can be used for small to moderate deformations.
     The diffusion parameter "alfa", which is specified by "extrapolation_sub_type",
@@ -41,7 +41,7 @@ def extrapolate_setup(F_fluid_linear, extrapolation_sub_type, mesh, d_, phi,
     else:
         raise RuntimeError("Could not find extrapolation method {}".format(extrapolation_sub_type))
 
-    for fluid_region in range(len(dx_f_id)): # for all fluid regions
+    for fluid_region in range(len(dx_f_id_list)): # for all fluid regions
         F_extrapolate = alfa * inner(grad(d_["n"]), grad(phi)) * dx_f[fluid_region]
         F_fluid_linear += F_extrapolate
 

--- a/turtleFSI/modules/no_fluid.py
+++ b/turtleFSI/modules/no_fluid.py
@@ -6,7 +6,7 @@
 from dolfin import Constant, inner
 
 
-def fluid_setup(psi, phi, dx_f,dx_f_id, mesh, **namespace):
+def fluid_setup(psi, phi, dx_f, dx_f_id, mesh, **namespace):
     F_fluid_linear = 0
     F_fluid_nonlinear = 0
     for fluid_region in range(len(dx_f_id)):

--- a/turtleFSI/modules/no_fluid.py
+++ b/turtleFSI/modules/no_fluid.py
@@ -6,10 +6,12 @@
 from dolfin import Constant, inner
 
 
-def fluid_setup(psi, phi, dx_f,mu_f, mesh, **namespace):
-    for fluid_region in range(len(mu_f)):
+def fluid_setup(psi, phi, dx_f,dx_f_id, mesh, **namespace):
+    F_fluid_linear = 0
+    F_fluid_nonlinear = 0
+    for fluid_region in range(len(dx_f_id)):
         """No contribution from the fluid, for when solving only the structure equation."""
-        F_fluid_linear = inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_f[fluid_region]
-        F_fluid_nonlinear = inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_f[fluid_region]
+        F_fluid_linear += inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_f[fluid_region]
+        F_fluid_nonlinear += inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_f[fluid_region]
 
     return dict(F_fluid_linear=F_fluid_linear, F_fluid_nonlinear=F_fluid_nonlinear)

--- a/turtleFSI/modules/no_fluid.py
+++ b/turtleFSI/modules/no_fluid.py
@@ -6,10 +6,10 @@
 from dolfin import Constant, inner
 
 
-def fluid_setup(psi, phi, dx_f, dx_f_id, mesh, **namespace):
+def fluid_setup(psi, phi, dx_f, dx_f_id_list, mesh, **namespace):
     F_fluid_linear = 0
     F_fluid_nonlinear = 0
-    for fluid_region in range(len(dx_f_id)):
+    for fluid_region in range(len(dx_f_id_list)):
         """No contribution from the fluid, for when solving only the structure equation."""
         F_fluid_linear += inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_f[fluid_region]
         F_fluid_nonlinear += inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_f[fluid_region]

--- a/turtleFSI/modules/no_fluid.py
+++ b/turtleFSI/modules/no_fluid.py
@@ -6,9 +6,10 @@
 from dolfin import Constant, inner
 
 
-def fluid_setup(psi, phi, dx_f, mesh, **namespace):
-    """No contribution from the fluid, for when solving only the structure equation."""
-    F_fluid_linear = inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_f
-    F_fluid_nonlinear = inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_f
+def fluid_setup(psi, phi, dx_f,mu_f, mesh, **namespace):
+    for fluid_region in range(len(mu_f)):
+        """No contribution from the fluid, for when solving only the structure equation."""
+        F_fluid_linear = inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_f[fluid_region]
+        F_fluid_nonlinear = inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_f[fluid_region]
 
     return dict(F_fluid_linear=F_fluid_linear, F_fluid_nonlinear=F_fluid_nonlinear)

--- a/turtleFSI/modules/no_fluid.py
+++ b/turtleFSI/modules/no_fluid.py
@@ -10,7 +10,7 @@ def fluid_setup(psi, phi, dx_f, dx_f_id_list, mesh, **namespace):
     F_fluid_linear = 0
     F_fluid_nonlinear = 0
     for fluid_region in range(len(dx_f_id_list)):
-        """No contribution from the fluid, for when solving only the structure equation."""
+        # No contribution from the fluid, for when solving only the structure equation.
         F_fluid_linear += inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_f[fluid_region]
         F_fluid_nonlinear += inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_f[fluid_region]
 

--- a/turtleFSI/modules/no_solid.py
+++ b/turtleFSI/modules/no_solid.py
@@ -6,7 +6,7 @@
 from dolfin import Constant, inner
 
 
-def solid_setup(psi, phi, dx_s_id, mesh, **namespace):
+def solid_setup(psi, phi, dx_s, dx_s_id, mesh, **namespace):
     F_solid_linear = 0
     F_solid_nonlinear = 0
     for solid_region in range(len(dx_s_id)):

--- a/turtleFSI/modules/no_solid.py
+++ b/turtleFSI/modules/no_solid.py
@@ -6,9 +6,10 @@
 from dolfin import Constant, inner
 
 
-def solid_setup(psi, phi, dx_s, mesh, **namespace):
-    """No contribution from the structure, for when solving only the fluid equation."""
-    F_solid_linear = inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_s
-    F_solid_nonlinear = inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_s
+def solid_setup(psi, phi, dx_s,mu_s, mesh, **namespace):
+    for solid_region in range(len(mu_s)):
+        """No contribution from the structure, for when solving only the fluid equation."""
+        F_solid_linear = inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_s[solid_region]
+        F_solid_nonlinear = inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_s[solid_region]
 
     return dict(F_solid_linear=F_solid_linear, F_solid_nonlinear=F_solid_nonlinear)

--- a/turtleFSI/modules/no_solid.py
+++ b/turtleFSI/modules/no_solid.py
@@ -6,10 +6,12 @@
 from dolfin import Constant, inner
 
 
-def solid_setup(psi, phi, dx_s,mu_s, mesh, **namespace):
-    for solid_region in range(len(mu_s)):
+def solid_setup(psi, phi, dx_s_id, mesh, **namespace):
+    F_solid_linear = 0
+    F_solid_nonlinear = 0
+    for solid_region in range(len(dx_s_id)):
         """No contribution from the structure, for when solving only the fluid equation."""
-        F_solid_linear = inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_s[solid_region]
-        F_solid_nonlinear = inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_s[solid_region]
+        F_solid_linear += inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_s[solid_region]
+        F_solid_nonlinear += inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_s[solid_region]
 
     return dict(F_solid_linear=F_solid_linear, F_solid_nonlinear=F_solid_nonlinear)

--- a/turtleFSI/modules/no_solid.py
+++ b/turtleFSI/modules/no_solid.py
@@ -6,10 +6,10 @@
 from dolfin import Constant, inner
 
 
-def solid_setup(psi, phi, dx_s, dx_s_id, mesh, **namespace):
+def solid_setup(psi, phi, dx_s, dx_s_id_list, mesh, **namespace):
     F_solid_linear = 0
     F_solid_nonlinear = 0
-    for solid_region in range(len(dx_s_id)):
+    for solid_region in range(len(dx_s_id_list)):
         """No contribution from the structure, for when solving only the fluid equation."""
         F_solid_linear += inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_s[solid_region]
         F_solid_nonlinear += inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_s[solid_region]

--- a/turtleFSI/modules/no_solid.py
+++ b/turtleFSI/modules/no_solid.py
@@ -10,7 +10,7 @@ def solid_setup(psi, phi, dx_s, dx_s_id_list, mesh, **namespace):
     F_solid_linear = 0
     F_solid_nonlinear = 0
     for solid_region in range(len(dx_s_id_list)):
-        """No contribution from the structure, for when solving only the fluid equation."""
+        # No contribution from the structure, for when solving only the fluid equation.
         F_solid_linear += inner(Constant(tuple([0] * mesh.geometry().dim())), psi) * dx_s[solid_region]
         F_solid_nonlinear += inner(Constant(tuple([0] * mesh.geometry().dim())), phi) * dx_s[solid_region]
 

--- a/turtleFSI/modules/solid.py
+++ b/turtleFSI/modules/solid.py
@@ -7,7 +7,7 @@ from turtleFSI.modules import *
 from dolfin import Constant, inner, grad
 
 
-def solid_setup(d_, v_, phi, psi, dx_s, mu_s, rho_s, lambda_s, k, theta,
+def solid_setup(d_, v_, phi, psi, dx_s, dx_s_id, mu_s, rho_s, lambda_s, k, theta,
                 gravity,mesh, **namespace):
 
     # DB added gravity in 3d functionality and multi material capability 16/3/21
@@ -29,11 +29,6 @@ def solid_setup(d_, v_, phi, psi, dx_s, mu_s, rho_s, lambda_s, k, theta,
     # Theta scheme constants
     theta0 = Constant(theta)
     theta1 = Constant(1 - theta)
-
-    if isinstance(mu_s,list)==False: # If there aren't multpile solid regions, convert solid variables to lists
-        rho_s=[rho_s]
-        mu_s=[mu_s]
-        lambda_s=[lambda_s]
 
     F_solid_linear = 0
     F_solid_nonlinear = 0

--- a/turtleFSI/modules/solid.py
+++ b/turtleFSI/modules/solid.py
@@ -32,7 +32,7 @@ def solid_setup(d_, v_, phi, psi, dx_s, dx_s_id, mu_s, rho_s, lambda_s, k, theta
 
     F_solid_linear = 0
     F_solid_nonlinear = 0
-    for solid_region in range(len(mu_s)):
+    for solid_region in range(len(dx_s_id)):
         # Temporal term and convection
         F_solid_linear += (rho_s[solid_region]/k * inner(v_["n"] - v_["n-1"], psi)*dx_s[solid_region]
                           + delta * rho_s[solid_region] * (1 / k) * inner(d_["n"] - d_["n-1"], phi) * dx_s[solid_region]

--- a/turtleFSI/modules/solid.py
+++ b/turtleFSI/modules/solid.py
@@ -7,7 +7,7 @@ from turtleFSI.modules import *
 from dolfin import Constant, inner, grad
 
 
-def solid_setup(d_, v_, phi, psi, dx_s, dx_s_id, mu_s, rho_s, lambda_s, k, theta,
+def solid_setup(d_, v_, phi, psi, dx_s, dx_s_id_list, mu_s_list, rho_s_list, lambda_s_list, k, theta,
                 gravity,mesh, **namespace):
 
     # DB added gravity in 3d functionality and multi material capability 16/3/21
@@ -18,7 +18,7 @@ def solid_setup(d_, v_, phi, psi, dx_s, dx_s_id, mu_s, rho_s, lambda_s, k, theta
     ALE formulation (theta-scheme) of the non-linear elastic problem:
     dv/dt - f + div(sigma) = 0   with v = d(d)/dt
     """
-    # dx_s2, mu_s2, rho_s2, lambda_s2,
+
     # From the equation defined above we have to include the equation v - d(d)/dt = 0. This
     # ensures both that the variable d and v is well defined in the solid equation, but also
     # that there is continuity of the velocity at the boundary. Since this is imposed weakly
@@ -32,18 +32,18 @@ def solid_setup(d_, v_, phi, psi, dx_s, dx_s_id, mu_s, rho_s, lambda_s, k, theta
 
     F_solid_linear = 0
     F_solid_nonlinear = 0
-    for solid_region in range(len(dx_s_id)):
+    for solid_region in range(len(dx_s_id_list)):
         # Temporal term and convection
-        F_solid_linear += (rho_s[solid_region]/k * inner(v_["n"] - v_["n-1"], psi)*dx_s[solid_region]
-                          + delta * rho_s[solid_region] * (1 / k) * inner(d_["n"] - d_["n-1"], phi) * dx_s[solid_region]
-                          - delta * rho_s[solid_region] * inner(theta0 * v_["n"] + theta1 * v_["n-1"], phi) * dx_s[solid_region])
+        F_solid_linear += (rho_s_list[solid_region]/k * inner(v_["n"] - v_["n-1"], psi)*dx_s[solid_region]
+                          + delta * rho_s_list[solid_region] * (1 / k) * inner(d_["n"] - d_["n-1"], phi) * dx_s[solid_region]
+                          - delta * rho_s_list[solid_region] * inner(theta0 * v_["n"] + theta1 * v_["n-1"], phi) * dx_s[solid_region])
         # Stress
-        F_solid_nonlinear += theta0 * inner(Piola1(d_["n"], lambda_s[solid_region], mu_s[solid_region]), grad(psi)) * dx_s[solid_region]
-        F_solid_linear += theta1 * inner(Piola1(d_["n-1"], lambda_s[solid_region], mu_s[solid_region]), grad(psi)) * dx_s[solid_region]
+        F_solid_nonlinear += theta0 * inner(Piola1(d_["n"], lambda_s_list[solid_region], mu_s_list[solid_region]), grad(psi)) * dx_s[solid_region]
+        F_solid_linear += theta1 * inner(Piola1(d_["n-1"], lambda_s_list[solid_region], mu_s_list[solid_region]), grad(psi)) * dx_s[solid_region]
         # Gravity
         if gravity is not None and mesh.geometry().dim() == 2:
-            F_solid_linear -= inner(Constant((0, -gravity * rho_s[solid_region])), psi)*dx_s[solid_region] 
+            F_solid_linear -= inner(Constant((0, -gravity * rho_s_list[solid_region])), psi)*dx_s[solid_region] 
         elif gravity is not None and mesh.geometry().dim() == 3:
-            F_solid_linear -= inner(Constant((0, -gravity * rho_s[solid_region],0)), psi)*dx_s[solid_region] 
+            F_solid_linear -= inner(Constant((0, -gravity * rho_s_list[solid_region],0)), psi)*dx_s[solid_region] 
 
     return dict(F_solid_linear=F_solid_linear, F_solid_nonlinear=F_solid_nonlinear)

--- a/turtleFSI/monolithic.py
+++ b/turtleFSI/monolithic.py
@@ -108,8 +108,20 @@ dS = Measure("dS", subdomain_data=boundaries)
 dx = Measure("dx", subdomain_data=domains)
 
 # Domains
-dx_f = dx(dx_f_id, subdomain_data=domains)
-dx_s = dx(dx_s_id, subdomain_data=domains)
+dx_f = {}
+if isinstance(dx_f_id, list): # If dx_f_id is a list (if there are multiple solid regions):
+    for fluid_region in range(len(dx_f_id)):
+        dx_f[fluid_region] = dx(dx_f_id[fluid_region], subdomain_data=domains) # Create dx_f for each solid region
+else:
+    dx_f[0] = dx(dx_f_id, subdomain_data=domains)
+
+dx_s = {}
+if isinstance(dx_s_id, list): # If dx_s_id is a list (if there are multiple solid regions):
+    for solid_region in range(len(dx_s_id)):
+        dx_s[solid_region] = dx(dx_s_id[solid_region], subdomain_data=domains) # Create dx_s for each solid region
+else:
+    dx_s[0] = dx(dx_s_id, subdomain_data=domains)
+
 
 # Define solver
 # Adding the Matrix() argument is a FEniCS 2018.1.0 hack

--- a/turtleFSI/monolithic.py
+++ b/turtleFSI/monolithic.py
@@ -109,9 +109,9 @@ dx = Measure("dx", subdomain_data=domains)
 
 # Domains
 dx_f = {}
-if isinstance(dx_f_id, list): # If dx_f_id is a list (if there are multiple solid regions):
+if isinstance(dx_f_id, list): # If dx_f_id is a list (if there are multiple fluid regions):
     for fluid_region in range(len(dx_f_id)):
-        dx_f[fluid_region] = dx(dx_f_id[fluid_region], subdomain_data=domains) # Create dx_f for each solid region
+        dx_f[fluid_region] = dx(dx_f_id[fluid_region], subdomain_data=domains) # Create dx_f for each fluid region
 else:
     dx_f[0] = dx(dx_f_id, subdomain_data=domains)
 

--- a/turtleFSI/monolithic.py
+++ b/turtleFSI/monolithic.py
@@ -109,18 +109,22 @@ dx = Measure("dx", subdomain_data=domains)
 
 # Domains
 dx_f = {}
-if isinstance(dx_f_id, list): # If dx_f_id is a list (if there are multiple fluid regions):
+if isinstance(dx_f_id, list): # If dx_f_id is a list (i.e, if there are multiple fluid regions):
     for fluid_region in range(len(dx_f_id)):
         dx_f[fluid_region] = dx(dx_f_id[fluid_region], subdomain_data=domains) # Create dx_f for each fluid region
 else:
     dx_f[0] = dx(dx_f_id, subdomain_data=domains)
+    mu_f=[mu_f] # If there aren't multpile fluid regions, and the fluid viscosity is given as a float,convert to list.
 
 dx_s = {}
-if isinstance(dx_s_id, list): # If dx_s_id is a list (if there are multiple solid regions):
+if isinstance(dx_s_id, list): # If dx_s_id is a list (i.e, if there are multiple solid regions):
     for solid_region in range(len(dx_s_id)):
         dx_s[solid_region] = dx(dx_s_id[solid_region], subdomain_data=domains) # Create dx_s for each solid region
 else:
     dx_s[0] = dx(dx_s_id, subdomain_data=domains)
+    rho_s=[rho_s] # If there aren't multpile solid regions, and the solid parameters are given as floats, convert solid parameters to lists.
+    mu_s=[mu_s]
+    lambda_s=[lambda_s]
 
 
 # Define solver

--- a/turtleFSI/monolithic.py
+++ b/turtleFSI/monolithic.py
@@ -108,6 +108,7 @@ dS = Measure("dS", subdomain_data=boundaries)
 dx = Measure("dx", subdomain_data=domains)
 
 # Domains
+# DB, May 2nd, 2022: All these conversions to lists seem a bit cumbersome, but this allows the solver to be backwards compatible.
 dx_f = {}
 if isinstance(dx_f_id, list): # If dx_f_id is a list (i.e, if there are multiple fluid regions):
     for fluid_region in range(len(dx_f_id)):

--- a/turtleFSI/monolithic.py
+++ b/turtleFSI/monolithic.py
@@ -115,6 +115,7 @@ if isinstance(dx_f_id, list): # If dx_f_id is a list (i.e, if there are multiple
 else:
     dx_f[0] = dx(dx_f_id, subdomain_data=domains)
     mu_f=[mu_f] # If there aren't multpile fluid regions, and the fluid viscosity is given as a float,convert to list.
+    dx_f_id=[dx_f_id]
 
 dx_s = {}
 if isinstance(dx_s_id, list): # If dx_s_id is a list (i.e, if there are multiple solid regions):
@@ -125,6 +126,7 @@ else:
     rho_s=[rho_s] # If there aren't multpile solid regions, and the solid parameters are given as floats, convert solid parameters to lists.
     mu_s=[mu_s]
     lambda_s=[lambda_s]
+    dx_s_id=[dx_s_id]
 
 
 # Define solver

--- a/turtleFSI/monolithic.py
+++ b/turtleFSI/monolithic.py
@@ -112,21 +112,27 @@ dx_f = {}
 if isinstance(dx_f_id, list): # If dx_f_id is a list (i.e, if there are multiple fluid regions):
     for fluid_region in range(len(dx_f_id)):
         dx_f[fluid_region] = dx(dx_f_id[fluid_region], subdomain_data=domains) # Create dx_f for each fluid region
+    mu_f_list=mu_f # 
+    dx_f_id_list=dx_f_id
 else:
     dx_f[0] = dx(dx_f_id, subdomain_data=domains)
-    mu_f=[mu_f] # If there aren't multpile fluid regions, and the fluid viscosity is given as a float,convert to list.
-    dx_f_id=[dx_f_id]
+    mu_f_list=[mu_f] # If there aren't multpile fluid regions, and the fluid viscosity is given as a float,convert to list.
+    dx_f_id_list=[dx_f_id]
 
 dx_s = {}
 if isinstance(dx_s_id, list): # If dx_s_id is a list (i.e, if there are multiple solid regions):
     for solid_region in range(len(dx_s_id)):
         dx_s[solid_region] = dx(dx_s_id[solid_region], subdomain_data=domains) # Create dx_s for each solid region
+    rho_s_list=rho_s
+    mu_s_list=mu_s
+    lambda_s_list=lambda_s
+    dx_s_id_list=dx_s_id
 else:
     dx_s[0] = dx(dx_s_id, subdomain_data=domains)
-    rho_s=[rho_s] # If there aren't multpile solid regions, and the solid parameters are given as floats, convert solid parameters to lists.
-    mu_s=[mu_s]
-    lambda_s=[lambda_s]
-    dx_s_id=[dx_s_id]
+    rho_s_list=[rho_s] # If there aren't multpile solid regions, and the solid parameters are given as floats, convert solid parameters to lists.
+    mu_s_list=[mu_s]
+    lambda_s_list=[lambda_s]
+    dx_s_id_list=[dx_s_id]
 
 
 # Define solver


### PR DESCRIPTION
This feature allows you to assign different fluid and solid properties to different regions of the simulation. For example, to assign multiple fluid regions with different viscosity, you can now pass in a list of fluid ids and corresponding viscosity:
        mu_f=[3.5E-3, 35.0E-3],       # Fluid dynamic viscosity [Pa.s]
        dx_f_id=[1,1001],      # ID of marker in the fluid domain. 

Likewise, you can pass in multiple solid ids and the corresponding properties:
        rho_s=[1.0E3,1.0E3],    # Solid density [kg/m3]
        mu_s=[5.0E4,4.0E4],     # Solid shear modulus or 2nd Lame Coef. [Pa]
        nu_s=[0.45,0.40],      # Solid Poisson ratio [-]
        lambda_s=[4.5E5,4.0E5],  # Solid 1st Lame Coef. [Pa]
        dx_s_id=[2,3],      # ID of marker in the solid domain

All old problem files will still work because you can still pass in single values for solid and fluid properties.