### PR TITLE
avoid printing from all the ranks when running with mpi

### DIFF
--- a/turtleFSI/modules/common.py
+++ b/turtleFSI/modules/common.py
@@ -132,7 +132,8 @@ def Piola1(d, solid_properties):
         elif solid_properties["material_model"] == "Gent":
             W = W_Gent(F, solid_properties["mu_s"], solid_properties["Jm"])  
         else:
-            print('Invalid entry for material_model, choose from ["StVenantKirchoff",""StVenantKirchoffEnergy","NeoHookean","MooneyRivlin","Gent"]')
+            if MPI.rank(MPI.comm_world) == 0:
+                print('Invalid entry for material_model, choose from ["StVenantKirchoff",""StVenantKirchoffEnergy","NeoHookean","MooneyRivlin","Gent"]')
         
         P = ufl.diff(W, F) # First Piola-Kirchoff Stress for compressible hyperelastic material (https://en.wikipedia.org/wiki/Hyperelastic_material)
     

--- a/turtleFSI/utils/__init__.py
+++ b/turtleFSI/utils/__init__.py
@@ -8,8 +8,10 @@ except ModuleNotFoundError:
     try:
         import cppimport
     except ModuleNotFoundError:
-        print(msg.format("cppimport"))
+        if MPI.rank(MPI.comm_world) == 0:
+            print(msg.format("cppimport"))
     try:
         import mpi4py
     except ModuleNotFoundError:
-        print(msg.format("mpi4py"))
+        if MPI.rank(MPI.comm_world) == 0:
+            print(msg.format("mpi4py"))


### PR DESCRIPTION
Since some of the print statement was written without mpi.rank=0 I added them to avoid unnecessary print. 