### PR TITLE
delete fenicstools from the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,7 @@ However, if you are using Linux or MaxOSX you can install turtleFSI through anac
         conda create -n your_environment -c conda-forge turtleFSI
 
 You can then activate your environment by runing ``source activate your_environment``.
-You are now all set, and can start running fluid-structure interaction simulations. If 
-you would like to use ``save_deg > 1``, then please install fenicstools by runningthe following::
-
-	pip install git+https://github.com/mikaem/fenicstools
+You are now all set, and can start running fluid-structure interaction simulations.
 
 Use
 ---

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -13,7 +13,6 @@ The dependencies of turtleFSI are:
 * FEniCS 2019.1.0
 * Numpy >1.1X
 * Python >=3.7
-* FEniCStools 2019.1.0 (optional)
 
 Basic Installation
 ==================
@@ -31,11 +30,7 @@ turtleFSI can be found `here <https://turtlefsi2.readthedocs.io/en/latest/using_
 If you are using turtleFSI on a high performance computing (HPC) cluster we always
 recommend that you build from source, as described below. This is in accordance
 with the guidelines provided by the `FEniCS project <https://fenicsproject.org/download/>`_
-users to install FEniCS from source when on a HPC cluster. To have a fully featured version
-of turtleFSI you would also need to install fenicstools manually with::
-
-     $ pip install git+https://github.com/mikaem/fenicstools
-
+users to install FEniCS from source when on a HPC cluster. 
 
 Development version
 ===================
@@ -61,5 +56,4 @@ Then, you can install turtleFSI be executing the following::
     $ python setup.py install
 
 If you are installing turtleFSI somewhere you do not have root access, typically on a cluster, you can add
-``--user`` to install locally. If you are using fenicstools to use the ``save_deg`` functionality, follow the
-same procedure, but clone the `fenicstools git repository <https://github.com/mikaem/fenicstools>`_ instead.
+``--user`` to install locally.


### PR DESCRIPTION
We do not use `fenicstools` anymore, thus delete from the documentation. 