### PR TITLE
Allow nested lists in config files

### DIFF
--- a/docs/examples/example.config
+++ b/docs/examples/example.config
@@ -67,10 +67,10 @@ nu-s=0.45
 # 1st Lame Coef. for the solid
 lambda-s=4.5E5
 
-# Elastic response necesary for RobinBC
+# Elastic response necessary for RobinBC
 k_s=0.0
 
-# Viscoelastic response necesary for RobinBC
+# Viscoelastic response necessary for RobinBC
 c_s=0.0
 
 # Gravitational force on the solid

--- a/docs/examples/example.yaml
+++ b/docs/examples/example.yaml
@@ -67,10 +67,10 @@ nu-s: 0.45
 # 1st Lame Coef. for the solid
 lambda-s: 4.5E5
 
-# Elastic response necesary for RobinBC
+# Elastic response necessary for RobinBC
 k_s: 0.0
 
-# Viscoelastic response necesary for RobinBC
+# Viscoelastic response necessary for RobinBC
 c_s: 0.0
 
 # Gravitational force on the solid

--- a/turtleFSI/utils/argpar.py
+++ b/turtleFSI/utils/argpar.py
@@ -293,6 +293,7 @@ def parse():
         args.__dict__.pop("new_arguments")
 
     # Add unknown arguments
+    unknownargs_dict = {}
     for arg in unknownargs:
         d = {}
         k, v = arg.strip("--").split('=')
@@ -302,12 +303,15 @@ def parse():
             d[k] = v
 
         # Treat list items (given as --item1=1 --item2=2...)
-        if k in args.__dict__:
-            if not isinstance(args.__dict__[k], list):
-                args.__dict__.update({k: [args.__dict__[k]]})
-            args.__dict__.update({k: args.__dict__[k] + [d[k]]})
+        if k in unknownargs_dict:
+            if not isinstance(unknownargs_dict[k], list):
+                unknownargs_dict.update({k: [unknownargs_dict[k]]})
+            unknownargs_dict.update({k: unknownargs_dict[k] + [d[k]]})
         else:
-            args.__dict__.update(d)
+            if isinstance(d[k], list):
+                d[k] = [d[k]]  # nested list
+            unknownargs_dict.update(d)
+    args.__dict__.update(unknownargs_dict)
 
     # Update the default values and then set the entire dictionary to be the inpute from
     # argparse


### PR DESCRIPTION
This allows to use nested lists in config files, for example like this:
``` ini
probe_points=[[0.000391, -0.001916, 0.000150], [0.001286, -0.000529, -0.001027], [-0.000170, 0.001041, -0.000218], [8.373301e-05, 0.002781, 0.0001315]]
```