### PR TITLE
fix tf_csm problem

### DIFF
--- a/tests/test_turtleFSI.py
+++ b/tests/test_turtleFSI.py
@@ -30,8 +30,8 @@ def test_csm():
 
     distance_x = np.loadtxt("tmp/2/dis_x.txt")[-1]
     distance_y = np.loadtxt("tmp/2/dis_y.txt")[-1]
-    distance_x_reference = -3.312418050495862e-05
-    distance_y_reference = -0.003738529237136441
+    distance_x_reference = -3.313014369394714527e-05
+    distance_y_reference = -3.770127311444726199e-03
 
     assert np.isclose(distance_x, distance_x_reference)
     assert np.isclose(distance_y, distance_y_reference)

--- a/turtleFSI/problems/TF_csm.py
+++ b/turtleFSI/problems/TF_csm.py
@@ -21,13 +21,11 @@ def set_problem_parameters(default_variables, **namespace):
     # Parameters
     default_variables.update(dict(
         # Temporal variables
-        T=30,          # End time [s]
+        T=10,          # End time [s]
         dt=0.01,       # Time step [s]
-        theta=0.5,     # Temporal scheme
+        theta=0.51,     # Temporal scheme
 
         # Physical constants
-        rho_f=1.0e3,   # Fluid density [kg/m3]
-        mu_f=1.0,      # Fluid dynamic viscosity [Pa.s]
         rho_s=1.0e3,   # Solid density[kg/m3]
         mu_s=0.5e6,    # Shear modulus, 2nd Lame Coef. CSM3: 0.5E6 [Pa]
         nu_s=0.4,      # Solid Poisson ratio [-]
@@ -84,8 +82,9 @@ def initiate(f_L, R, c_x, c_y, **namespace):
 def create_bcs(DVP, boundaries, **namespace):
     # Clamp on the left hand side
     u_barwall = DirichletBC(DVP.sub(0), ((0.0, 0.0)), boundaries, 1)
+    v_barwall = DirichletBC(DVP.sub(1), ((0.0, 0.0)), boundaries, 1)
 
-    return dict(bcs=[u_barwall])
+    return dict(bcs=[u_barwall, v_barwall])
 
 ################################################################################
 # the function mpi4py_comm and peval are used to overcome FEniCS limitation of


### PR DESCRIPTION
I was testing `TF_csm` (pure solid benchmark problem) and noticed that velocity was not correct with vey high value at the clamped side (left side). 
![TF_csm](https://github.com/KVSlab/turtleFSI/assets/42674006/cdfb5d9f-7de3-48d3-949c-8e2ce21231a8)


I added boundary condition for the velocity and that fixed the problem. I compared the displacement against Turek reference value and confirmed that these values are pretty close to the reference value. 