### PR TITLE
make sure dx_s_id is kept as int

### DIFF
--- a/turtleFSI/utils/argpar.py
+++ b/turtleFSI/utils/argpar.py
@@ -275,7 +275,7 @@ def parse():
     
     if args.__dict__["solid_properties"]:
         for k, v in args.__dict__["solid_properties"].items():
-            if k != "material_model":
+            if k != "material_model" and k != "dx_s_id":
                 args.__dict__["solid_properties"][k] = float(v)
     
     if args.__dict__["fluid_properties"]:


### PR DESCRIPTION
When using `solid_properties` from config file, I noticed that `dx_s_id` (domain ID for solid) was converted from `int` to `float`. This can cause minor problem inside `VaSP` for computing stress/strain. This PR should fix the issue.